### PR TITLE
Fixed nodejs package file

### DIFF
--- a/CouponDB/npm's.txt
+++ b/CouponDB/npm's.txt
@@ -1,4 +1,0 @@
-npm install express --save
-npm install sqlite3
-npm install mocha
-npm test (mangler package.json?)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rewards_service",
+  "version": "0.0.1",
+  "description": "Rewards microservice",
+  "main": "CouponDB/coupon.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DAT210/Rewards.git"
+  },
+  "author": "Group7",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/DAT210/Rewards/issues"
+  },
+  "homepage": "https://github.com/DAT210/Rewards#readme",
+  "dependencies": {
+    "express": "^4.16.3",
+    "mocha": "^5.2.0",
+    "sqlite3": "^4.0.2"
+  }
+}


### PR DESCRIPTION
To initialize a nodejs project run `npm init` and answer the prompts

Install packages with `npm install <package-name> --save` if it's a project dependency (express, sqlite3...), if you're installing a development tool (like node-dev) you should install it with `npm install -g <package-name>`

Before running the program with `node <app.js>` you need to run `npm install` to install all the dependencies on your machine.